### PR TITLE
Make injecting secret the current best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This bundle has updated security by not rolling its own encryption and using ver
 ```yml
 // Config.yml
 ambta_doctrine_encrypt:
-    encryptor_class: Halite
+    encryptor_class: Halite  # Default value
 ```
 
 ### Using [Defuse](https://github.com/defuse/php-encryption)
@@ -44,21 +44,38 @@ ambta_doctrine_encrypt:
     encryptor_class: Defuse
 ```
 
-
-
 ### Secret key
 
-The secret key should be a max 32 byte hexadecimal string (`[0-9a-fA-F]`).
+The current best practice is to inject the secret through an environment variable or by using [a symfony secret](https://symfony.com/doc/current/configuration/secrets.html).
 
-Secret key is generated if there is no key found. This is automatically generated and stored in the folder defined in the configuration
+You can generate a new secret using the GenerateSecretCommand: `bin/console doctrine:encrypt:generate-secret`.  
+
+This will generate a secret if the configured encryptor_class allows secret-generation.
+
+The default encryptors Halite and Defuse allow generating a new secret. When you use a custom encryptor which supports
+generating a secret, the command will be able to generate a secret as well.
 
 ```yml
-// Config.yml
+# config/ambta_doctrine_encrypt.yml
 ambta_doctrine_encrypt:
+    secret: '%env(HALITE_SECRET)%'
+```
+
+#### Automatic secret generation
+Optionally, you can configure the bundle to generate a secret and store it in a default location if no key is found.
+It will be stored in the folder defined in the configuration
+
+```yml
+# config/ambta_doctrine_encrypt.yml
+ambta_doctrine_encrypt:
+    enable_secret_generation: true
     secret_directory_path: '%kernel.project_dir%'   # Default value
 ```
 
-Filename example: `.DefuseEncryptor.key` or `.HaliteEncryptor.key`
+The filenames for the generated key will be:
+* Defuse: `.Defuse.key`
+* Halite: `.Halite.key`
+* Custom encryptor: `.DoctrineEncryptBundle.key`
 
 **Do not forget to add these files to your .gitignore file, you do not want this on your repository!**
 

--- a/demo/symfony6.x/config/packages/ambta_doctrine_encrypt.yaml
+++ b/demo/symfony6.x/config/packages/ambta_doctrine_encrypt.yaml
@@ -1,3 +1,4 @@
 ambta_doctrine_encrypt:
+  encryptor_class: 'Defuse'
   enable_secret_generation: false
   secret: '%env(HALITE_SECRET)%'

--- a/src/Command/GenerateSecretCommand.php
+++ b/src/Command/GenerateSecretCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Ambta\DoctrineEncryptBundle\Command;
+
+use Ambta\DoctrineEncryptBundle\Encryptors\SecretGeneratorInterface;
+use ParagonIE\Halite\KeyFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class GenerateSecretCommand extends Command
+{
+    protected static $defaultName        = 'doctrine:encrypt:generate-secret';
+    protected static $defaultDescription = 'Generate encryption key for encryption';
+
+    /**
+     * @var string
+     * @phpstan-var class-string
+     */
+    private $encryptorClass;
+
+    public function __construct(
+        /** @phpstan-param class-string $encryptorClass */
+        string $encryptorClass,
+        ?string $name = null
+    )
+    {
+        parent::__construct($name);
+
+        $this->encryptorClass = $encryptorClass;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input,$output);
+        if (!is_a($this->encryptorClass, SecretGeneratorInterface::class, true)) {
+            $io->error('Unable to generate a secret. Please configure an encryptor which can generate a secret');
+
+            return Command::FAILURE;
+        }
+
+        $encryptionKey = call_user_func([$this->encryptorClass, 'generateSecret'])->getString();
+
+        $output->writeln("
+<info>New secret
+==============</info>
+$encryptionKey
+
+<info>Example-usage
+=============</info>
+
+# config/packages/ambta_doctrine_encrypt.yaml
+ambta_doctrine_encrypt:
+  secret: '%env(HALITE_SECRET)%'
+
+# .env.local
+HALITE_SECRET=\"$encryptionKey\"
+");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('%kernel.project_dir%')
                 ->end()
                 ->booleanNode('enable_secret_generation')
-                    ->defaultValue(true)
+                    ->defaultValue(false)
                 ->end()
                 ->scalarNode('secret')
                     ->defaultValue(null)

--- a/src/Encryptors/DefuseEncryptor.php
+++ b/src/Encryptors/DefuseEncryptor.php
@@ -2,6 +2,7 @@
 
 namespace Ambta\DoctrineEncryptBundle\Encryptors;
 
+use ParagonIE\HiddenString\HiddenString;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -10,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * @author Michael de Groot <specamps@gmail.com>
  */
 
-class DefuseEncryptor implements EncryptorInterface
+class DefuseEncryptor implements EncryptorInterface, SecretGeneratorInterface
 {
     /** @var string  */
     private $secret;
@@ -37,5 +38,10 @@ class DefuseEncryptor implements EncryptorInterface
     public function decrypt(string $data): string
     {
         return \Defuse\Crypto\Crypto::decryptWithPassword($data, $this->secret);
+    }
+
+    public static function generateSecret(): HiddenString
+    {
+        return new HiddenString(bin2hex(random_bytes(255)));
     }
 }

--- a/src/Encryptors/HaliteEncryptor.php
+++ b/src/Encryptors/HaliteEncryptor.php
@@ -13,7 +13,7 @@ use ParagonIE\Halite\Symmetric\Crypto;
  * @author Michael de Groot <specamps@gmail.com>
  */
 
-class HaliteEncryptor implements EncryptorInterface
+class HaliteEncryptor implements EncryptorInterface, SecretGeneratorInterface
 {
     /** @var EncryptionKey|null  */
     private $encryptionKey = null;
@@ -53,8 +53,8 @@ class HaliteEncryptor implements EncryptorInterface
         return $this->encryptionKey;
     }
 
-    public function validateSecret()
+    public static function generateSecret(): HiddenString
     {
-        $this->getKey();
+        return KeyFactory::export(KeyFactory::generateEncryptionKey());
     }
 }

--- a/src/Encryptors/SecretGeneratorInterface.php
+++ b/src/Encryptors/SecretGeneratorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Encryptors;
+
+use ParagonIE\HiddenString\HiddenString;
+
+interface SecretGeneratorInterface
+{
+    public static function generateSecret(): HiddenString;
+}

--- a/src/Exception/DoctrineEncyptBundleException.php
+++ b/src/Exception/DoctrineEncyptBundleException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Exception;
+
+class DoctrineEncyptBundleException extends \Exception
+{
+
+}

--- a/src/Exception/UnableToGenerateSecretException.php
+++ b/src/Exception/UnableToGenerateSecretException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Exception;
+
+use Ambta\DoctrineEncryptBundle\Exception\DoctrineEncyptBundleException;
+
+class UnableToGenerateSecretException extends DoctrineEncyptBundleException
+{
+
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -38,3 +38,9 @@ services:
             - "@doctrine.orm.entity_manager"
             - "@ambta_doctrine_annotation_reader"
             - "@ambta_doctrine_encrypt.subscriber"
+
+    ambta_doctrine_encrypt.command.generate_secret:
+        class: Ambta\DoctrineEncryptBundle\Command\GenerateSecretCommand
+        tags: ['console.command']
+        arguments:
+            - "%ambta_doctrine_encrypt.encryptor_class_name%"

--- a/src/Resources/config/services_with_secretfactory.yml
+++ b/src/Resources/config/services_with_secretfactory.yml
@@ -2,10 +2,11 @@ services:
   ambta_doctrine_encrypt.encryptor:
     class: "%ambta_doctrine_encrypt.encryptor_class_name%"
     arguments:
-      - '@=service("ambta_doctrine_encrypt.secret_factory").getSecret(parameter("ambta_doctrine_encrypt.encryptor_class_name"))'
+      - '@=service("ambta_doctrine_encrypt.secret_factory").getSecret()'
 
   ambta_doctrine_encrypt.secret_factory:
     class: Ambta\DoctrineEncryptBundle\Factories\SecretFactory
     arguments:
+      $encryptor:            '%ambta_doctrine_encrypt.encryptor_class_name%'
       $secretDirectory:      '%ambta_doctrine_encrypt.secret_directory_path%'
       $enableSecretCreation: '%ambta_doctrine_encrypt.enable_secret_generation%'

--- a/tests/Unit/DependencyInjection/fixtures/TestEncryptor.php
+++ b/tests/Unit/DependencyInjection/fixtures/TestEncryptor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ambta\DoctrineEncryptBundle\Tests\Unit\DependencyInjection\fixtures;
+
+use Ambta\DoctrineEncryptBundle\Encryptors\EncryptorInterface;
+use Ambta\DoctrineEncryptBundle\Encryptors\SecretGeneratorInterface;
+use ParagonIE\HiddenString\HiddenString;
+
+class TestEncryptor implements SecretGeneratorInterface, EncryptorInterface
+{
+    public const SECRET = 'S3cr3t!';
+
+    public function encrypt(string $data): string
+    {
+        return strrev($data);
+    }
+
+    public function decrypt(string $data): string
+    {
+        return strrev($data);
+    }
+
+    public static function generateSecret(): HiddenString
+    {
+        return new HiddenString(self::SECRET);
+    }
+}


### PR DESCRIPTION
* Add command to generate a secret
* Make configuration-key ambta_doctrine_encrypt.enable_secret_generation default to false
* Move secret-generation from the SecretFactory to the Encryptors itself
* Add interface to Encryptors to signal they support generating secrets for themselves
* Add base-exception for this project
* Throw specific exception when failing to generate exception instead of \RuntimeException